### PR TITLE
Passing tests for Datasets, Roles, Users

### DIFF
--- a/tests/mock_loginsight_server/datasets_mock.py
+++ b/tests/mock_loginsight_server/datasets_mock.py
@@ -58,8 +58,7 @@ class MockedDatasetsMixin(requests_mock.Adapter):
     def __add(self, request, context, session_id, user_id):
         body = request.json()
         print("Got blob from client", body)
-        assert 'dataSet' in body
-        newitem = body['dataSet']
+        newitem = body
         assert 'name' in newitem
         assert 'id' not in newitem
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 
 import pytest
-from pyloginsight.models import Role
+from pyloginsight.models import Role, Roles
 import uuid
 
 
@@ -17,11 +17,11 @@ def test_setitem(connection):
 def test_append_and_delete(connection):
     d = connection.server.roles
 
-    name = "testdataset-" + str(uuid.uuid4())
+    name = "testrole-" + str(uuid.uuid4())
 
     original_quantity = len(d)
 
-    o = Role(name=name, description='mydescription')
+    o = Role(name=name, description='mydescription', capabilities=["ANALYTICS"])
     assert 'id' not in o
 
     new_object_guid = d.append(o)
@@ -38,3 +38,22 @@ def test_append_and_delete(connection):
 
     # Back to starting point
     assert len(d) == original_quantity
+
+
+def test_parse_roles():
+    roles_dict = {'roles': [{'capabilities': [{'id': 'DASHBOARD'}], 'editable': True, 'dataSets': [], 'id': 'b7b56e53-55ea-41c5-af0c-4da7c3787789', 'name': 'Dashboard User', 'description': 'Can use only Dashboards', 'required': False}, {'capabilities': [{'id': 'ANALYTICS'}, {'id': 'VIEW_ADMIN'}, {'id': 'INTERNAL'}, {'id': 'EDIT_SHARED'}, {'id': 'EDIT_ADMIN'}, {'id': 'STATISTICS'}, {'id': 'INVENTORY'}, {'id': 'DASHBOARD'}], 'editable': False, 'dataSets': [], 'id': '00000000-0000-0000-0000-000000000001', 'name': 'Super Admin', 'description': 'Full Admin and User capabilities, including editing Shared content', 'required': True}, {'capabilities': [{'id': 'ANALYTICS'}, {'id': 'DASHBOARD'}], 'editable': True, 'dataSets': [], 'id': '00000000-0000-0000-0000-000000000002', 'name': 'User', 'description': 'Can use Interactive Analytics and Dashboards', 'required': True}, {'capabilities': [{'id': 'ANALYTICS'}, {'id': 'VIEW_ADMIN'}, {'id': 'EDIT_SHARED'}, {'id': 'DASHBOARD'}], 'editable': True, 'dataSets': [], 'id': '3f31d0ab-c648-4251-a012-b1b5897bf850', 'name': 'View Only Admin', 'description': 'Can view Admin info and has full User access, including editing Shared content', 'required': False}]}
+
+    collection_class = Roles
+
+    Single = collection_class._single
+    collection = collection_class(None)
+
+    collection.asdict = lambda: roles_dict
+
+    count = 0
+    for key, value in collection.items():
+        count += 1
+        assert isinstance(key, (u"".__class__, "".__class__, int))
+        assert isinstance(value, Single)
+
+    assert count == len(collection)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -130,13 +130,16 @@ def test_change_user_password(connection_with_temporary_testuser):
     # Backup
     original_auth = connection._authprovider
 
-    # Try to login with the old password, should fail
+    def type_to_provider(t):
+        return {'DEFAULT': 'Local'}[t]
+
+    logger.info("Try to login with the old password, should fail")
     with pytest.raises(Unauthorized):
-        connection._authprovider = Credentials(username=user.username, password="abc!-DEF!-123!", provider=verification.type)
+        connection._authprovider = Credentials(username=user.username, password="abc!-DEF!-123!", provider=type_to_provider(user.type))
         current_session = connection.server.current_session
 
-    # Try to login
-    connection._authprovider = Credentials(username=user.username, password="abc!-DEF!-123!CHANGED", provider=verification.type)
+    logger.info("Try to login with new credentials")
+    connection._authprovider = Credentials(username=user.username, password="abc!-DEF!-123!CHANGED", provider=type_to_provider(user.type))
     current_session = connection.server.current_session
     print("current_session", current_session)
 


### PR DESCRIPTION
Password modification & verification works.
New users can authenticate.
Roles can be created & appended.

Bonus: --server command line argument can be specified
multiple times, allowing tests against a mock and live
server concurrently. Default remains mockserverlocal:9543