### PR TITLE
Feature: Query implementation for Events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 - 3.7-dev
 - nightly
 - pypy
+- pypy3
 matrix:
   fast_finish: true
   allow_failures:
@@ -16,6 +17,7 @@ matrix:
   - python: 3.7-dev
   - python: nightly
   - python: pypy
+  - python: pypy3
 install:
 - pip install --upgrade pip
 - pip install pep8==1.7.0

--- a/pyloginsight/ingestion.py
+++ b/pyloginsight/ingestion.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# VMware vRealize Log Insight SDK
+# Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import logging
+import pytz
+from datetime import datetime
+from .exceptions import ServerError
+
+logger = logging.getLogger(__name__)
+
+MAXIMUM_BYTES_TEXT_FIELD = 1024 * 16  # 16 KB (text field)
+
+
+def datetime_in_milliseconds(dt):
+    """
+    :param dt: Instance of datetime.datetime
+    :return: Unix timestamp in milliseconds since epoch
+    """
+    try:
+        return int(dt.timestamp() * 1000)
+    except AttributeError:
+        _EPOCH = datetime(1970, 1, 1, tzinfo=pytz.utc)
+        return int((dt - _EPOCH).total_seconds() * 1000)
+
+
+def crush_invalid_field_name(name):
+    """
+    Log Insight field names must start with an underscore or an alpha character.
+    :param name: A proposed field name
+    :return: Field name with invalid characters replaced by underscores (_), and runs of underscores
+    """
+    if name[0].isdigit():
+        name = "_%s" % name
+    name = re.sub(r'[^a-z0-9_]', "_", name.lower())
+    return re.sub(r'__*', "_", name, flags=re.I)
+
+
+def serialize_cfapi_event(message, timestamp_milliseconds, fields):
+    """
+
+    :param message: A str to use as the message body
+    :param timestamp_milliseconds: An integer
+    :param fields: A dict of fields.
+    :return:
+    """
+    o = {}
+    if message:
+        o['text'] = message[:MAXIMUM_BYTES_TEXT_FIELD]
+    if timestamp_milliseconds:
+        o['timestamp'] = timestamp_milliseconds
+    if fields:
+        pass
+        o['fields'] = [{'name': crush_invalid_field_name(str(k)), 'content': str(v)} for k, v in fields.items()]
+    return o
+
+
+def serialize_event_object(event_object):
+    try:
+        ms = datetime_in_milliseconds(event_object.timestamp)
+    except AttributeError:
+        ms = None
+
+    return serialize_cfapi_event(event_object.get('text', None), ms, event_object.get('fields', None))
+
+
+def transmit(connection, event_object, agent_id="1", trusted=False):
+    """Transmit a single Event object to a remote Log Insight server."""
+
+    e = serialize_event_object(event_object)
+
+    r = connection.post("/events/ingest/" + agent_id, json={"events": [e]}, sendauthorization=trusted)
+
+    if r.get("status", None) == 'ok':
+        return r.get("ingested", 0)
+
+    raise ServerError(r)

--- a/pyloginsight/operator.py
+++ b/pyloginsight/operator.py
@@ -24,4 +24,4 @@ GT = ">"
 LT = "<"
 GE = ">="
 LE = "<="
-_NUMERIC = [NOTEQUAL, EQUAL, GT, LT, GE, LE, LAST]
+_NUMERIC = [NOTEQUAL, EQUAL, GE, LE, GT, LT, LAST]

--- a/pyloginsight/query.py
+++ b/pyloginsight/query.py
@@ -19,10 +19,12 @@
 
 # A "Constraint" consists of (field, operator, value).
 
-from . import operators as operator
+from . import operator
 from requests.utils import quote
 import warnings
+from datetime import datetime, timedelta
 from .abstracts import ServerAddressableObject, AppendableServerDictMixin, ServerDictMixin
+from .ingestion import datetime_in_milliseconds
 
 
 class Queries(AppendableServerDictMixin, ServerDictMixin, ServerAddressableObject):
@@ -55,6 +57,11 @@ class Constraint:
 
     def __str__(self):
         """Url-encode each of the arguments, and return a query fragment like `/field/operator value`."""
+
+        if isinstance(self.value, datetime):
+            self.value = datetime_in_milliseconds(self.value)
+        if isinstance(self.value, timedelta):
+            self.value = self.value.total_seconds()
         if self.operator in operator._NUMERIC:
             self.value = str(int(self.value))
         if self.operator in operator._TIME and self.field != 'timestamp':

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ class ToxTest(TestCommand):
         errno = main(args)
         sys.exit(errno)
 
-runtime_requirements = ['requests', 'marshmallow', 'attrdict', 'six']
+runtime_requirements = ['requests', 'marshmallow', 'attrdict', 'six', 'pytz']
 
 setup(
     name='pyloginsight',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,3 +4,8 @@ six
 marshmallow
 attrdict
 pytz
+requests_mock
+pytest
+pytest-catchlog
+pytest-flakes
+pytest-pep8

--- a/tests/mock_loginsight_server/__init__.py
+++ b/tests/mock_loginsight_server/__init__.py
@@ -10,7 +10,7 @@ from .exampleobject import MockedExampleObjectMixin
 from .auth_providers import MockedAuthProvidersMixin
 from .bootstrap import MockedBootstrapMixin
 
-
+from .query_and_ingestion import MockedEventDataMixin
 from .datasets_mock import MockedDatasetsMixin
 from .groups_mock import MockedGroupsMixin
 from .roles_mock import MockedRolesMixin
@@ -32,6 +32,7 @@ class LogInsightMockAdapter(MockedExampleObjectMixin,
                             MockedRolesMixin,
                             MockedGroupsMixin,
                             MockedDatasetsMixin,
+                            MockedEventDataMixin,
                             MockedBootstrapMixin,
                             MockedVersionMixin,
                             MockedLicensesMixin,

--- a/tests/mock_loginsight_server/query_and_ingestion.py
+++ b/tests/mock_loginsight_server/query_and_ingestion.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+
+import requests_mock
+import json
+import logging
+import re
+from functools import wraps
+import time
+from six.moves import urllib
+from pyloginsight import operator
+
+from .utils import RandomDict, requiresauthentication, uuid_url_matcher, guid
+
+logger = logging.getLogger("LogInsightMockAdapter").getChild(__name__)
+
+"""
+Minimal mock of a Log Insight events ingestion and query system.
+Leaves out many edge-cases.
+No support for regex matching or globs or tokenization.
+No support for OR'd constraints, so `/appname/contains vpxa/appname/contains vpxd` will never match.
+"""
+
+
+def query_path_url_matcher(base):
+    return re.compile('/api/v1/' + base + '(/.*)$')
+
+
+def url_to_constraints(path):
+    url_query_chunk = query_path_url_matcher('[^/]+').match(path).group(1)
+    print("url_query_chunk", url_query_chunk)
+
+    path_split = url_query_chunk.split("/")
+    print("path_split", path_split)
+
+    a = iter(path_split)
+    next(a)  # leading slash
+
+    def mutate(iterable):
+        for fieldname, encoded_argument in iterable:
+            argument = urllib.parse.unquote_plus(encoded_argument)
+            if argument.upper() in operator._BOOLEAN:
+                yield (fieldname, argument.upper(), None)
+                continue
+
+            for potential_operator in operator._NUMERIC + operator._STRING + operator._TIME:
+                if argument.upper().startswith(potential_operator):
+                    value = argument[len(potential_operator):]
+                    yield (fieldname, potential_operator, value)
+                    break
+            else:
+                raise ValueError("Mock cannot parse field/operator+value: %s/%s" % (fieldname, argument))
+
+    return mutate(zip(a, a))
+
+
+def query_components(fn):
+    """Server mock; grab the object guid from the url"""
+    @wraps(fn)
+    def wrapper(self, request, context, *args, **kwargs):
+        constraints = list(url_to_constraints(request.path))
+        return fn(self, request=request, context=context, constraints=constraints, params={}, *args, **kwargs)
+
+    return wrapper
+
+
+class MockedEventDataMixin(requests_mock.Adapter):
+    def __init__(self, **kwargs):
+        super(MockedEventDataMixin, self).__init__(**kwargs)
+
+        self.__known = RandomDict()
+
+        # Query
+        self.register_uri('GET', query_path_url_matcher('events'), status_code=200, text=self.__events)
+        self.register_uri('GET', query_path_url_matcher('aggregated-events'), status_code=200, text=self.Raise418)
+
+        self.register_uri('POST', uuid_url_matcher('events/ingest'), status_code=200, text=self.__ingest)
+
+        # Two datasets
+        self.__known = [
+            {"timestamp": 0, "text": "beginning of time", "fields": [{"name": "appname", "content": "pyloginsight test"}]},
+            {"timestamp": 12345678900, "text": "sequence epoch", "fields": [{"name": "appname", "content": "pyloginsight test"}]},
+        ]
+
+    @guid
+    def __ingest(self, request, context, guid):
+        body = request.json()
+        print("Got blob from client", body)
+
+        try:
+            events = body['events']
+        except KeyError:
+            context.status_code = 400
+            return "{'errorMessage': 'Missing events'}"
+
+        for e in events:
+            # add default values to event
+            if 'timestamp' not in e:
+                e['timestamp'] = int(time.time() * 1000.0)  # Now
+            if 'text' not in e:
+                e['text'] = ""
+            if 'fields' not in e:
+                e['fields'] = []
+            print("e", e)
+
+            self.__known.append(e)
+
+        return json.dumps({'ingested': len(events), 'status': 'ok', 'message': 'events ingested'})
+
+    def prep(self):
+        pass
+
+    @requiresauthentication
+    @query_components
+    def __events(self, request, context, constraints, params, session_id, user_id):
+        # (?P<field>[0-9a-z_]+)/(?P<operator>[<>=] (?P)
+        return json.dumps({'events': list(self.__query_filter(constraints))})
+
+    @requiresauthentication
+    def __aggregate(self, request, context, session_id, user_id):
+        pass
+
+    def __query_filter(self, constraints):
+        for event in self.__known:
+            if all([evaluate_constraint(event, c) for c in constraints]):
+                print("Emitting event", event)
+                yield event
+            else:
+                print("NOT emitting event", event)
+
+
+def all_fields_as_dict(event):
+    return dict((f['name'], f['content']) for f in event['fields'])
+
+
+def evaluate_constraint(event, constraint):
+    """Rudimentary query execution. Returns True if the event is permitted by this constraint, False otherwise."""
+    (fieldname, op, value) = constraint
+    print("Evaluating event", event, "against constraint", constraint)
+
+    event_fields = all_fields_as_dict(event)
+
+    # Existence operators
+    if op == operator.EXISTS:
+        return fieldname in ('text', 'timestamp') + tuple(event_fields.keys())
+
+    if fieldname == "text":
+        subject = event['text']
+    elif fieldname == "timestamp":
+        subject = event['timestamp']
+    else:
+        subject = event.get(fieldname, None)
+
+    # String operators
+    if op in (operator.CONTAINS, operator.HAS):
+        return value in subject
+    if op in (operator.NOT_CONTAINS, operator.NOT_HAS):
+        return value not in subject
+
+    # TODO: Regex operators
+
+    # Numeric operators
+    try:
+        value = int(value)
+    except ValueError:
+        value = None
+
+    if op == operator.EQUAL:
+        return subject == value
+    if op == operator.NOTEQUAL:
+        return subject != value
+    if op == operator.GT:
+        return subject > value
+    if op == operator.LT:
+        return subject < value
+    if op == operator.GE:
+        return subject >= value
+    if op == operator.LE:
+        return subject <= value
+
+    raise NotImplementedError("Support for operator '%s' not implemented by mock" % op)

--- a/tests/mock_loginsight_server/utils.py
+++ b/tests/mock_loginsight_server/utils.py
@@ -43,7 +43,7 @@ def guid(fn):
     """Server mock; grab the object guid from the url"""
     @wraps(fn)
     def wrapper(self, request, context, *args, **kwargs):
-        guid = uuid_url_matcher('[^/]+').match(request.path).group(1)
+        guid = uuid_url_matcher('.+').match(request.path).group(1)
         return fn(self, request=request, context=context, guid=guid, *args, **kwargs)
 
     return wrapper

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,8 +2,18 @@
 from __future__ import print_function
 import pytest
 import warnings
+import collections
+import uuid
+
+from pyloginsight.exceptions import TransportError
 from pyloginsight.query import Constraint, Parameter
-from pyloginsight import operators as operator
+from pyloginsight import operator
+from pyloginsight.models import Event
+from pyloginsight.ingestion import serialize_event_object, crush_invalid_field_name
+from datetime import datetime
+import pytz
+import time
+import json
 
 """Examples from "Specifying constraints" section of https://vmw-loginsight.github.io/#Querying-data"""
 
@@ -55,5 +65,121 @@ def test_constraint_exists():
 
 
 def test_parameters():
-    x = Parameter(order="ASC", limit=4, timeout=20, contentpackfields="x,y,z", super="abc")
-    print(x)
+    _ = Parameter(order="ASC", limit=4, timeout=20, contentpackfields="x,y,z", super="abc")
+
+
+def test_query_conditions(connection):
+    """
+    Run a live query against a remote server.
+    """
+
+    # All time, default limit of 100 events
+    conditions = [Constraint("source", operator.EXISTS), Constraint("timestamp", ">=", 0)]
+    events = connection.server.events(conditions)
+
+    assert isinstance(events, collections.Sized)
+
+
+def test_ping_pong_message(connection):
+    """Ingest a message and then query it back."""
+
+    events = None
+    e = Event(text=str(uuid.uuid4()), fields={'appname': 'pyloginsight test'}, timestamp=datetime.now(pytz.utc).replace(microsecond=0))
+
+    connection.server.log(e)
+
+    conditions = [Constraint("text", operator.CONTAINS, e['text']), Constraint("timestamp", "=", e['timestamp'])]
+
+    # The event will traverse the ingestion pipeline asynchronously.
+    # Poll the server 100 times with a 0.05 second delay in 5 seconds, plus request overhead
+    attempt = 0
+    for attempt in range(100):
+        events = connection.server.events(conditions)
+        assert isinstance(events, collections.Sequence)
+        if len(events) > 0:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail("Timeout waiting for event to appear in query results")
+
+    assert len(events) > 0
+    assert isinstance(events[0], Event)
+    assert isinstance(events[0].fields, collections.Mapping)
+    assert isinstance(events[0].timestamp, datetime)
+
+    # Other than server-added fields...
+    for f in ('event_type', 'source', 'hostname'):
+        try:
+            del events[0]['fields'][f]
+        except KeyError:
+            pass
+
+    # The originally-send and query-result events are equal
+    assert events[0] == e
+
+    print("Completed in %d attempts" % attempt)
+
+
+def test_ingest_single_message(connection):
+    """
+    Create and ingest a new log message with text=uuid and the current datetime.
+    If the server rejects the event or cannot parse it, this raises an exception.
+    """
+    e = Event(
+        text=str(uuid.uuid4()),
+        fields={'appname': 'pyloginsight test'},
+        timestamp=datetime.now(pytz.utc)
+    )
+
+    connection.server.log(e)
+
+
+def test_ingest_single_empty_message(connection):
+    """It is possible to ingest a completely empty Event. It serializes to {}"""
+    e = Event()
+    connection.server.log(e)
+
+
+def test_ingest_pathalogical_field_name(connection):
+    pathalogic = '''field @#$%^&/;\,.<a>'"value'''
+    e = Event(
+        text=str(uuid.uuid4()),
+        fields={'appname': 'pyloginsight test', pathalogic: 'pyloginsight test'},
+        timestamp=datetime.now(pytz.utc)
+    )
+    assert 'field_a_value' == crush_invalid_field_name(pathalogic)
+    assert 'field_a_value' in json.dumps(serialize_event_object(e))
+    connection.server.log(e)
+
+
+def test_ingest_pathalogical_field_value(connection):
+    pathalogic = '''field @#$%^&/;\,.<a>'"value'''
+    e = Event(
+        text=str(uuid.uuid4()),
+        fields={'appname': 'pyloginsight test', 'pyloginsight test': pathalogic},
+        timestamp=datetime.now(pytz.utc)
+    )
+    connection.server.log(e)
+
+
+def test_event_repr():
+    e = Event(
+        text=str(uuid.uuid4()),
+        fields={'appname': 'pyloginsight test'},
+        timestamp=datetime.now(pytz.utc)
+    )
+    assert 'datetime' in repr(e)
+    assert 'appname' in repr(e)
+    assert 'text=' in repr(e)
+    print(e)
+
+
+def test_ingest_without_any_events_fails(connection):
+    """Transmit a single garbage object to a remote Log Insight server."""
+    with pytest.raises(TransportError):
+        r = connection.post("/events/ingest/0", json={"foo": "bar"}, sendauthorization=False)
+
+
+def test_ingest_extra_fields_succeeds(connection):
+    """Transmit an empty list of events, along with extra data which should be ignored."""
+    r = connection.post("/events/ingest/0", json={"events": [], "foo": "bar"}, sendauthorization=False)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,pypy
+envlist = py27,py34,py35,py36,pypy3
 usedevelop = True
 
 [testenv]
@@ -42,3 +42,6 @@ flakes-ignore =
     docs/ ALL
 
 addopts = --flakes --pep8
+
+[pep8]
+max-line-length = 180


### PR DESCRIPTION
Log Events can be ingested by the server, and queried back.
This is the bare minimum functionality needed for a database.

Rudimentary mock of server's query interface covers central
feature set but ignores many edge-cases. Tests should be run
against the mock and a live server by specifying --server twice.

No support for Aggregate queries yet (count, average).